### PR TITLE
req_agent bug

### DIFF
--- a/lib/agent_zeromq/agents/req_agent.rb
+++ b/lib/agent_zeromq/agents/req_agent.rb
@@ -22,7 +22,7 @@ class AgentZeroMQ::ReqAgent
   end
 
   def publish msg
-    AgentZeroMQ::Helpers.publish(msg, zmq_socket)
+    AgentZeroMQ::Helpers.publish(zmq_socket, msg)
     AgentZeroMQ::Helpers.read_msg zmq_socket
  end
 


### PR DESCRIPTION
I found a bug in the req_agent. The 'publish' method, which calls the 'helpers.publish(socket, msg)' method, was passing its arguments in reverse order. As in it was calling 'helpers.publish(msg, socket)'. So the helpers' publish method was trying to call 'send_string' on msg, instead of socket.
